### PR TITLE
[validation] Adding unformatter in validation

### DIFF
--- a/src/middlewares/validations.js
+++ b/src/middlewares/validations.js
@@ -286,14 +286,16 @@ export const formatValue = (value, entityPath, fieldName, definitions, domains) 
         Object.keys(element).map((propertyNameLine)=> {
           const domain = domains[redirectDefinition[propertyNameLine].domain];
           const {formatter = defaultFormatter} = domain || {};
-          newElement[propertyNameLine] = formatter(element[propertyNameLine]);
+          const {unformatter = defaultFormatter} = domain || {};
+          newElement[propertyNameLine] = unformatter !== defaultFormatter ? unformatter(element[propertyNameLine]) : formatter(element[propertyNameLine]);
         })
         return newElement;
       })
       return value;
     }
     const {formatter = defaultFormatter} = domains[domainName] || {};
-    return formatter(value);
+    const {unformatter = defaultFormatter} = domains[domainName] || {};
+    return unformatter !== defaultFormatter ? unformatter(value) : formatter(value);
 };
 
 


### PR DESCRIPTION
## [validation] Adding unformatter in validation

## Description 

Until now the unformatter isn't treated. I've just added a check when it's on the domain.

The functions (formatter/unformatter) shouldn't be declared at the same time on the same domain.

@TomGallon how can i be sure about that ? What do you thing about that ?


> Fixes #148 